### PR TITLE
Fix deprecated say usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ async def on_command_completion(ctx):
 @bot.command(pass_context=True)
 async def killbot(ctx):
     print("Shutting down!")
-    await bot.say("Shutting down.")
+    await ctx.send("Shutting down.")
     await bot.close()
 
 

--- a/cogs/Members.py
+++ b/cogs/Members.py
@@ -41,7 +41,7 @@ class Members(commands.Cog):
             return await ctx.message.channel.send("That is not a valid voice channel.")
         members = voice_channel.members
         if len(members) < amount:
-            return await self.say("Sample larger than population.")
+            return await ctx.message.channel.send("Sample larger than population.")
         member_names = [x.display_name for x in members]
         msg = random.sample(member_names, int(amount))
 


### PR DESCRIPTION
## Summary
- replace `bot.say` in `killbot` with `ctx.send`
- replace deprecated `self.say` with `ctx.message.channel.send`
- confirm no other `say` uses exist

## Testing
- `python -m compileall -q .`
- `pytest -q`