### PR TITLE
Fix dat filename handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+usrdat.pickle

--- a/cogs/Thirstyboi.py
+++ b/cogs/Thirstyboi.py
@@ -1,7 +1,6 @@
 # Stdlib imports
 import datetime
 import pickle
-import pickle
 import asyncio
 
 # Third party and local imports
@@ -275,7 +274,7 @@ def dat_export(usrdat, allwchan, filename: str = "usrdat.pickle"):
 
 def dat_import(filename: str = "usrdat.pickle"):
     '''Import data from file.'''
-    with open("userdat.pickle", "rb") as fp:
+    with open(filename, "rb") as fp:
         users, allowed_chan = pickle.load(fp)
     return users, allowed_chan
 


### PR DESCRIPTION
## Summary
- deduplicate `pickle` import
- respect filename argument in `dat_import`
- ignore `usrdat.pickle`

## Testing
- `python -m py_compile $(git ls-files '*.py')`